### PR TITLE
Make ShutdownHookUtils public

### DIFF
--- a/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/cli/ShutdownHookUtils.java
+++ b/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/cli/ShutdownHookUtils.java
@@ -29,7 +29,7 @@ import java.security.AccessControlException;
  *
  * @author Kristian Rosenvold
  */
-class ShutdownHookUtils
+public class ShutdownHookUtils
 {
 
     public static void addShutDownHook( Thread hook )


### PR DESCRIPTION
It can be re-used in surefire to remove some code-duplication
