### PR TITLE
Upgrade the dependency on maven-artifact for maven-shared-io

### DIFF
--- a/maven-shared-io/pom.xml
+++ b/maven-shared-io/pom.xml
@@ -34,7 +34,7 @@
   <description>API for I/O support like logging, download or file scanning.</description>
 
   <prerequisites>
-    <maven>2.0.6</maven>
+    <maven>2.2.1</maven>
   </prerequisites>
 
   <contributors>
@@ -69,22 +69,22 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>2.0.2</version>
+      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact-manager</artifactId>
-      <version>2.0.2</version>
+      <version>2.2.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-provider-api</artifactId>
-      <version>1.0-alpha-6</version>
+      <version>1.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0</version>
+      <version>2.2.1</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/maven-shared-io/src/test/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategyTest.java
+++ b/maven-shared-io/src/test/java/org/apache/maven/shared/io/location/ArtifactLocatorStrategyTest.java
@@ -426,7 +426,7 @@ public class ArtifactLocatorStrategyTest
         {
             resolver.resolve( artifact, Collections.EMPTY_LIST, localRepository );
             expectLastCall().andThrow( new ArtifactNotFoundException( "not found", "group", "artifact", "version",
-                                                                               "jar", Collections.EMPTY_LIST,
+                                                                               "jar", null, Collections.EMPTY_LIST,
                                                                                "http://nowhere.com", Collections.EMPTY_LIST,
                                                                                 new NullPointerException() ) );
         }
@@ -471,7 +471,7 @@ public class ArtifactLocatorStrategyTest
         {
             resolver.resolve( artifact, Collections.EMPTY_LIST, localRepository );
             expectLastCall().andThrow( new ArtifactResolutionException( "resolution failed", "group", "artifact",
-                                                                                 "version", "jar", Collections.EMPTY_LIST,
+                                                                                 "version", "jar", null, Collections.EMPTY_LIST,
                                                                                  Collections.EMPTY_LIST,
                                                                                  new NullPointerException() ) );
         }


### PR DESCRIPTION
Hi,

A maven-shared-io test doesn't compile against maven-artifact 2.2.1 because the signature of a constructor changed in `org.apache.maven.artifact.resolver.ArtifactResolutionException`.

Here is a patch fixing this. An alternative would be to put back the missing constructor in ArtifactResolutionException.
