### PR TITLE
[MSHARED-545] Advance the index for longs and doubles

### DIFF
--- a/maven-dependency-analyzer/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
+++ b/maven-dependency-analyzer/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java
@@ -117,9 +117,11 @@ public class ConstantPoolParser
                     break;
                 case CONSTANT_DOUBLE:
                     buf.getDouble();
+                    ix++;
                     break;
                 case CONSTANT_LONG:
                     buf.getLong();
+                    ix++;
                     break;
                 case CONSTANT_METHODHANDLE:
                     buf.get();

--- a/maven-dependency-analyzer/src/test/resources/java8methodRefs/src/main/java/inlinedStaticReference/Project.java
+++ b/maven-dependency-analyzer/src/test/resources/java8methodRefs/src/main/java/inlinedStaticReference/Project.java
@@ -26,6 +26,8 @@ import org.apache.commons.io.FileUtils;
 
 public class Project
 {
+    public static final long LONG_CONSTANT = 123L;
+    public static final double DOUBLE_CONSTANT = 123.0d;
     public static final Function<String, File> souv = FileUtils::getFile;
 
     public Project() {


### PR DESCRIPTION
As you can see in the [stack overflow answer](http://stackoverflow.com/questions/32255023/how-would-i-go-about-parsing-the-java-class-file-constant-pool/32278587#32278587) this code was adapted from, the index must be advanced when you encounter a long or double. Without this change, you hit [this](https://github.com/apache/maven-shared/blob/ca1f714442eb49439a1f184ba8177e7795158b75/maven-dependency-analyzer/src/main/java/org/apache/maven/shared/dependency/analyzer/asm/ConstantPoolParser.java#L96) exception on the next loop iteration. 

I added an example of this to one of the test classes. Without the corresponding change to `ConstantPoolParser`, the test fails but it passes with this change.

@krosenvold @khmarbaise 
