### PR TITLE
bug fix: silently fails overwriting symlinks

### DIFF
--- a/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
+++ b/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
@@ -40,6 +40,8 @@ public class Java7Support
 
     private static Method delete;
 
+    private static Method deleteIfExists;
+
     private static Method toPath;
 
     private static Method exists;
@@ -66,6 +68,7 @@ public class Java7Support
             Class<?> linkOption = cl.loadClass( "java.nio.file.LinkOption" );
             isSymbolicLink = files.getMethod( "isSymbolicLink", path );
             delete = files.getMethod( "delete", path );
+            deleteIfExists = files.getMethod( "deleteIfExists", path );
             readSymlink = files.getMethod( "readSymbolicLink", path );
 
             emptyFileAttributes = Array.newInstance( fa, 0 );
@@ -170,13 +173,10 @@ public class Java7Support
     {
         try
         {
-            if ( !exists( symlink ) )
-            {
-                Object link = toPath.invoke( symlink );
-                Object path = createSymlink.invoke( null, link, toPath.invoke( target ), emptyFileAttributes );
-                return (File) toFile.invoke( path );
-            }
-            return symlink;
+            Object link = toPath.invoke( symlink );
+            deleteIfExists.invoke( null, link );
+            Object path = createSymlink.invoke( null, link, toPath.invoke( target ), emptyFileAttributes );
+            return (File) toFile.invoke( path );
         }
         catch ( IllegalAccessException e )
         {


### PR DESCRIPTION
This is a fix [MNG-6048](https://issues.apache.org/jira/browse/MNG-6048)

When A is an existing symlink to B, then createSymbolicLink(A,C) does
neither overwrite A->B by A->C (as expected in analogy to the behavior
of copy(A,C)) nor does it throw an exception nor does it return A->B to
indicate the failure, but it actually "silently fails", i. e. it returns
A->C!

This certainly is heavily problematic, unsymmetric to what
copy(File,File) and Files.createSymbolicLink(Path,Path) do, and
certainly unwanted and buggy behavior.

The solution is to delete any existing target before creating the
symlic, hence copying the behavior of copy(File,File).
