### PR TITLE
[MSHARED-562] override default colors with java properties

### DIFF
--- a/maven-shared-utils/pom.xml
+++ b/maven-shared-utils/pom.xml
@@ -91,6 +91,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.0</version>

--- a/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/logging/AnsiMessageBuffer.java
+++ b/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/logging/AnsiMessageBuffer.java
@@ -31,17 +31,22 @@ class AnsiMessageBuffer
 
     AnsiMessageBuffer()
     {
-        ansi = Ansi.ansi();
+        this( Ansi.ansi() );
     }
 
     AnsiMessageBuffer( StringBuilder builder )
     {
-        ansi = Ansi.ansi( builder );
+        this( Ansi.ansi( builder ) );
     }
 
     AnsiMessageBuffer( int size )
     {
-        ansi = Ansi.ansi( size );
+        this( Ansi.ansi( size ) );
+    }
+
+    AnsiMessageBuffer( Ansi ansi )
+    {
+        this.ansi = ansi;
     }
 
     // consistent color management
@@ -54,24 +59,24 @@ class AnsiMessageBuffer
         ansi.bold().fgCyan();
         return this;
     }
-    
+
     public AnsiMessageBuffer info()
     {
         ansi.bold().fgBlue();
         return this;
     }
-    
+
     public AnsiMessageBuffer warning()
     {
         ansi.bold().fgYellow();
         return this;
     }
-    
+
     public AnsiMessageBuffer warning( Object message )
     {
         return warning().a( message ).reset();
     }
-    
+
     public AnsiMessageBuffer error()
     {
         ansi.bold().fgRed();
@@ -121,7 +126,7 @@ class AnsiMessageBuffer
     {
         return mojo().a( message ).reset();
     }
-    
+
 
     public AnsiMessageBuffer project()
     {

--- a/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/logging/AnsiMessageBuffer.java
+++ b/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/logging/AnsiMessageBuffer.java
@@ -21,6 +21,16 @@ package org.apache.maven.shared.utils.logging;
 
 import org.fusesource.jansi.Ansi;
 
+import static org.apache.maven.shared.utils.logging.Style.DEBUG;
+import static org.apache.maven.shared.utils.logging.Style.ERROR;
+import static org.apache.maven.shared.utils.logging.Style.FAILURE;
+import static org.apache.maven.shared.utils.logging.Style.INFO;
+import static org.apache.maven.shared.utils.logging.Style.MOJO;
+import static org.apache.maven.shared.utils.logging.Style.PROJECT;
+import static org.apache.maven.shared.utils.logging.Style.STRONG;
+import static org.apache.maven.shared.utils.logging.Style.SUCCESS;
+import static org.apache.maven.shared.utils.logging.Style.WARNING;
+
 /**
  * Message buffer implementation that supports ANSI colors through JAnsi.
  */
@@ -49,26 +59,21 @@ class AnsiMessageBuffer
         this.ansi = ansi;
     }
 
-    // consistent color management
-    // TODO make configurable
-    // settings.xml? during systemInstall(Settings)?
-    // or project properties (that can be injected by settings)?
-    //
     public AnsiMessageBuffer debug()
     {
-        ansi.bold().fgCyan();
+        DEBUG.apply( ansi );
         return this;
     }
 
     public AnsiMessageBuffer info()
     {
-        ansi.bold().fgBlue();
+        INFO.apply( ansi );
         return this;
     }
 
     public AnsiMessageBuffer warning()
     {
-        ansi.bold().fgYellow();
+        WARNING.apply( ansi );
         return this;
     }
 
@@ -79,13 +84,13 @@ class AnsiMessageBuffer
 
     public AnsiMessageBuffer error()
     {
-        ansi.bold().fgRed();
+        ERROR.apply( ansi );
         return this;
     }
 
     public AnsiMessageBuffer success()
     {
-        ansi.bold().fgGreen();
+        SUCCESS.apply( ansi );
         return this;
     }
 
@@ -96,7 +101,7 @@ class AnsiMessageBuffer
 
     public AnsiMessageBuffer failure()
     {
-        ansi.bold().fgRed();
+        FAILURE.apply( ansi );
         return this;
     }
 
@@ -107,7 +112,7 @@ class AnsiMessageBuffer
 
     public AnsiMessageBuffer strong()
     {
-        ansi.bold();
+        STRONG.apply( ansi );
         return this;
     }
 
@@ -118,7 +123,7 @@ class AnsiMessageBuffer
 
     public AnsiMessageBuffer mojo()
     {
-        ansi.fgGreen();
+        MOJO.apply( ansi );
         return this;
     }
 
@@ -130,7 +135,7 @@ class AnsiMessageBuffer
 
     public AnsiMessageBuffer project()
     {
-        ansi.fgCyan();
+        PROJECT.apply( ansi );
         return this;
     }
 

--- a/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/logging/Style.java
+++ b/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/logging/Style.java
@@ -1,0 +1,103 @@
+package org.apache.maven.shared.utils.logging;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.Ansi.Attribute;
+import org.fusesource.jansi.Ansi.Color;
+
+import static org.fusesource.jansi.Ansi.Attribute.INTENSITY_BOLD;
+
+/**
+ *
+ */
+enum Style
+{
+
+    DEBUG(   "bold,cyan"   ),
+    INFO(    "bold,blue"   ),
+    WARNING( "bold,yellow" ),
+    ERROR(   "bold,red"    ),
+    SUCCESS( "bold,green"  ),
+    FAILURE( "bold,red"    ),
+    STRONG(  "bold"        ),
+    MOJO(        "green"   ),
+    PROJECT(     "cyan"    );
+
+    private final Attribute attribute;
+
+    private final Color color;
+
+    Style( String defaultConfiguration )
+    {
+        Attribute currentAttribute = null;
+        Color currentColor = null;
+
+        for ( String token : System.getProperty( "style." + name().toLowerCase(), defaultConfiguration ).split( "," ) )
+        {
+            for ( Color color : Color.values() )
+            {
+                if ( color.toString().equalsIgnoreCase( token ) )
+                {
+                    currentColor = color;
+                }
+            }
+
+            if ( "bold".equalsIgnoreCase( token ) )
+            {
+                currentAttribute = INTENSITY_BOLD;
+            }
+        }
+
+        this.attribute = currentAttribute;
+        this.color = currentColor;
+    }
+
+    void apply( Ansi ansi )
+    {
+        if ( attribute != null )
+        {
+            ansi.a( attribute );
+        }
+        if ( color != null )
+        {
+            ansi.fg( color );
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        if ( attribute == null && color == null )
+        {
+            return name();
+        }
+        if ( attribute == null )
+        {
+            return name() + "=" + color.toString();
+        }
+        if ( color == null )
+        {
+            return name() + "=" + attribute.toString();
+        }
+        return name() + "=" + attribute + "," + color;
+    }
+
+}

--- a/maven-shared-utils/src/test/java/org/apache/maven/shared/utils/logging/AnsiMessageBufferTest.java
+++ b/maven-shared-utils/src/test/java/org/apache/maven/shared/utils/logging/AnsiMessageBufferTest.java
@@ -20,6 +20,7 @@ package org.apache.maven.shared.utils.logging;
  */
 
 import org.fusesource.jansi.Ansi;
+import org.fusesource.jansi.Ansi.Attribute;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,7 +28,14 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import static org.fusesource.jansi.Ansi.Attribute.INTENSITY_BOLD;
+import static org.fusesource.jansi.Ansi.Color.BLUE;
+import static org.fusesource.jansi.Ansi.Color.CYAN;
+import static org.fusesource.jansi.Ansi.Color.GREEN;
+import static org.fusesource.jansi.Ansi.Color.RED;
+import static org.fusesource.jansi.Ansi.Color.YELLOW;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 
 public class AnsiMessageBufferTest
@@ -43,7 +51,7 @@ public class AnsiMessageBufferTest
 
     @Before
     public void makesAnsiFluent() throws Exception {
-        given( ansi.bold() ).willReturn( ansi );
+        given( ansi.a( any( Attribute.class ) ) ).willReturn( ansi );
     }
 
     @Before
@@ -58,8 +66,8 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.debug();
 
         // then
-        verify( ansi ).bold();
-        verify( ansi ).fgCyan();
+        verify( ansi ).a( INTENSITY_BOLD );
+        verify( ansi ).fg( CYAN );
     }
 
     @Test
@@ -69,8 +77,8 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.info();
 
         // then
-        verify( ansi ).bold();
-        verify( ansi ).fgBlue();
+        verify( ansi ).a( INTENSITY_BOLD );
+        verify( ansi ).fg( BLUE );
     }
 
     @Test
@@ -80,8 +88,8 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.warning();
 
         // then
-        verify( ansi ).bold();
-        verify( ansi ).fgYellow();
+        verify( ansi ).a( INTENSITY_BOLD );
+        verify( ansi ).fg( YELLOW );
     }
 
     @Test
@@ -91,8 +99,8 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.error();
 
         // then
-        verify( ansi ).bold();
-        verify( ansi ).fgRed();
+        verify( ansi ).a( INTENSITY_BOLD );
+        verify( ansi ).fg( RED );
     }
 
     @Test
@@ -102,8 +110,8 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.success();
 
         // then
-        verify( ansi ).bold();
-        verify( ansi ).fgGreen();
+        verify( ansi ).a( INTENSITY_BOLD );
+        verify( ansi ).fg( GREEN );
     }
 
     @Test
@@ -113,8 +121,8 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.failure();
 
         // then
-        verify( ansi ).bold();
-        verify( ansi ).fgRed();
+        verify( ansi ).a( INTENSITY_BOLD );
+        verify( ansi ).fg( RED );
     }
 
     @Test
@@ -124,7 +132,7 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.strong();
 
         // then
-        verify( ansi ).bold();
+        verify( ansi ).a( INTENSITY_BOLD );
     }
 
     @Test
@@ -134,7 +142,7 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.mojo();
 
         // then
-        verify( ansi ).fgGreen();
+        verify( ansi ).fg( GREEN );
     }
 
     @Test
@@ -144,7 +152,7 @@ public class AnsiMessageBufferTest
         ansiMessageBuffer.project();
 
         // then
-        verify( ansi ).fgCyan();
+        verify( ansi ).fg( CYAN );
     }
 
 }

--- a/maven-shared-utils/src/test/java/org/apache/maven/shared/utils/logging/AnsiMessageBufferTest.java
+++ b/maven-shared-utils/src/test/java/org/apache/maven/shared/utils/logging/AnsiMessageBufferTest.java
@@ -1,0 +1,150 @@
+package org.apache.maven.shared.utils.logging;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.fusesource.jansi.Ansi;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+public class AnsiMessageBufferTest
+{
+
+    @Rule
+    public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+    @Mock
+    private Ansi ansi;
+
+    private AnsiMessageBuffer ansiMessageBuffer;
+
+    @Before
+    public void makesAnsiFluent() throws Exception {
+        given( ansi.bold() ).willReturn( ansi );
+    }
+
+    @Before
+    public void initializeAnsiMessageBuffer() {
+        this.ansiMessageBuffer = new AnsiMessageBuffer( ansi );
+    }
+
+    @Test
+    public void should_color_debug()
+    {
+        // when
+        ansiMessageBuffer.debug();
+
+        // then
+        verify( ansi ).bold();
+        verify( ansi ).fgCyan();
+    }
+
+    @Test
+    public void should_color_info()
+    {
+        // when
+        ansiMessageBuffer.info();
+
+        // then
+        verify( ansi ).bold();
+        verify( ansi ).fgBlue();
+    }
+
+    @Test
+    public void should_color_warning()
+    {
+        // when
+        ansiMessageBuffer.warning();
+
+        // then
+        verify( ansi ).bold();
+        verify( ansi ).fgYellow();
+    }
+
+    @Test
+    public void should_color_error()
+    {
+        // when
+        ansiMessageBuffer.error();
+
+        // then
+        verify( ansi ).bold();
+        verify( ansi ).fgRed();
+    }
+
+    @Test
+    public void should_color_success()
+    {
+        // when
+        ansiMessageBuffer.success();
+
+        // then
+        verify( ansi ).bold();
+        verify( ansi ).fgGreen();
+    }
+
+    @Test
+    public void should_color_failure()
+    {
+        // when
+        ansiMessageBuffer.failure();
+
+        // then
+        verify( ansi ).bold();
+        verify( ansi ).fgRed();
+    }
+
+    @Test
+    public void should_color_strong()
+    {
+        // when
+        ansiMessageBuffer.strong();
+
+        // then
+        verify( ansi ).bold();
+    }
+
+    @Test
+    public void should_color_mojo()
+    {
+        // when
+        ansiMessageBuffer.mojo();
+
+        // then
+        verify( ansi ).fgGreen();
+    }
+
+    @Test
+    public void should_color_project()
+    {
+        // when
+        ansiMessageBuffer.project();
+
+        // then
+        verify( ansi ).fgCyan();
+    }
+
+}


### PR DESCRIPTION
This pull request allow a user to redefine default maven colors with some java properties.

For example one can edit his `~/.mavenrc` with the following:

``` bash
MAVEN_OPTS="-Dstyle.info=cyan -Dstyle.warning=bold,yellow"
```

Possible values are (case _insensitive_):
- colors
  - `BLACK`
  - `RED`
  - `GREEN`
  - `YELLOW`
  - `BLUE`
  - `MAGENTA`
  - `CYAN`
  - `WHITE`
  - `DEFAULT`
- attributes
  - `BOLD`

Possible keys are (case _sensitive_ - always lowercase):
- `style.debug`
- `style.info`
- `style.warning`
- `style.error`
- `style.success`
- `style.failure`
- `style.strong`
- `style.mojo`
- `style.project`

This list is based on [MessageBuffer.java](https://github.com/apache/maven-shared/blob/trunk/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/logging/MessageBuffer.java) API and could evolve until final release.

Additional note about tests: as configuration is handled into one single enum thus testing with java property is merely impossible. Enum `Style` is already loaded when test is starting.
