### PR TITLE
MDEPLOY-214: Added property "retryFailedDeploymentDelay".

### DIFF
--- a/maven-artifact-transfer/src/main/java/org/apache/maven/shared/project/deploy/ProjectDeployerRequest.java
+++ b/maven-artifact-transfer/src/main/java/org/apache/maven/shared/project/deploy/ProjectDeployerRequest.java
@@ -34,6 +34,8 @@ public class ProjectDeployerRequest
 
     private int retryFailedDeploymentCount;
 
+    private int retryFailedDeploymentDelay;
+
     // From DeployMojo
 
     private MavenProject project;
@@ -75,6 +77,23 @@ public class ProjectDeployerRequest
     public ProjectDeployerRequest setRetryFailedDeploymentCount( int retryFailedDeploymentCount )
     {
         this.retryFailedDeploymentCount = retryFailedDeploymentCount;
+        return this;
+    }
+
+    /**
+     * @return the retryFailedDeploymentCount
+     */
+    public int getRetryFailedDeploymentDelay()
+    {
+        return retryFailedDeploymentDelay;
+    }
+
+    /**
+     * @param retryFailedDeploymentDelay the retryFailedDeploymentDelay to set
+     */
+    public ProjectDeployerRequest setRetryFailedDeploymentDelay( int retryFailedDeploymentDelay )
+    {
+        this.retryFailedDeploymentDelay = retryFailedDeploymentDelay;
         return this;
     }
 

--- a/maven-artifact-transfer/src/main/java/org/apache/maven/shared/project/deploy/internal/DefaultProjectDeployer.java
+++ b/maven-artifact-transfer/src/main/java/org/apache/maven/shared/project/deploy/internal/DefaultProjectDeployer.java
@@ -51,6 +51,7 @@ public class DefaultProjectDeployer
     implements ProjectDeployer
 {
     private static final Logger LOGGER = LoggerFactory.getLogger( DefaultProjectDeployer.class );
+    private static final int MAX_RETRY_DELAY = 300; // seconds
 
     @Requirement
     private ArtifactDeployer deployer;
@@ -95,6 +96,7 @@ public class DefaultProjectDeployer
         artifact.setRepository( artifactRepository );
 
         int retryFailedDeploymentCount = request.getRetryFailedDeploymentCount();
+        int retryFailedDeploymentDelay = request.getRetryFailedDeploymentDelay();
 
         try
         {
@@ -141,7 +143,8 @@ public class DefaultProjectDeployer
                 deployableArtifacts.add( attached );
             }
 
-            deploy( buildingRequest, deployableArtifacts, artifactRepository, retryFailedDeploymentCount );
+            deploy( buildingRequest, deployableArtifacts, artifactRepository, retryFailedDeploymentCount,
+                    retryFailedDeploymentDelay );
         }
         catch ( ArtifactDeployerException e )
         {
@@ -150,12 +153,14 @@ public class DefaultProjectDeployer
     }
 
     private void deploy( ProjectBuildingRequest request, Collection<Artifact> artifacts,
-                         ArtifactRepository deploymentRepository, int retryFailedDeploymentCount )
+                         ArtifactRepository deploymentRepository, int retryFailedDeploymentCount,
+                         int retryFailedDeploymentDelay )
         throws ArtifactDeployerException
     {
 
         // for now retry means redeploy the complete artifacts collection
         int retryFailedDeploymentCounter = Math.max( 1, Math.min( 10, retryFailedDeploymentCount ) );
+        int retryDelay = Math.max( 1, Math.min( MAX_RETRY_DELAY, retryFailedDeploymentDelay ) );
         ArtifactDeployerException exception = null;
         for ( int count = 0; count < retryFailedDeploymentCounter; count++ )
         {
@@ -177,6 +182,15 @@ public class DefaultProjectDeployer
                 {
                     LOGGER.warn( "Encountered issue during deployment: " + e.getLocalizedMessage() );
                     LOGGER.debug( e.getMessage() );
+                    try
+                    {
+                        LOGGER.warn( "retrying in " + retryDelay + " seconds." );
+                        Thread.sleep( retryDelay * 1000L );
+                    }
+                    catch ( InterruptedException e1 )
+                    {
+                        // ignored
+                    }
                 }
                 if ( exception == null )
                 {


### PR DESCRIPTION
This property impose a delay between 1 second to 5 minutes (max)
between retries. The intention is to make maven more
solid and stable when network glitches happens.

ticket https://issues.apache.org/jira/browse/MDEPLOY-214
in maven-deploy-plugin has the details.
