### PR TITLE
Moved newline for prettier print

### DIFF
--- a/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/xml/PrettyPrintXMLWriter.java
+++ b/maven-shared-utils/src/main/java/org/apache/maven/shared/utils/xml/PrettyPrintXMLWriter.java
@@ -366,10 +366,10 @@ public class PrettyPrintXMLWriter
 
         if ( docType != null )
         {
-            newLine();
             writer.write( "<!DOCTYPE " );
             writer.write( docType );
             writer.write( '>' );
+            newLine();
         }
     }
 


### PR DESCRIPTION
````
xml declaration
newline
doctype
newline
````

seems better than

````
xml declaration
newline
newline
doctype
````