### PR TITLE
[MJARSIGNER-53] - Add support of the "certchain" parameter in JarSigner sign operation

### DIFF
--- a/maven-jarsigner/pom.xml
+++ b/maven-jarsigner/pom.xml
@@ -61,15 +61,7 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-shared-utils</artifactId>
-      <!--
-      https://issues.apache.org/jira/browse/MSHARED-617
-      https://issues.apache.org/jira/browse/MSHARED-618
-      https://issues.apache.org/jira/browse/MSHARED-619
-      https://issues.apache.org/jira/browse/MSHARED-620
-      https://issues.apache.org/jira/browse/MSHARED-621
-      https://issues.apache.org/jira/browse/MSHARED-622
-      -->
-      <version>3.2.0-SNAPSHOT</version>
+      <version>3.2.0</version>
     </dependency>
 
     <dependency>

--- a/maven-jarsigner/src/main/java/org/apache/maven/shared/jarsigner/JarSignerCommandLineBuilder.java
+++ b/maven-jarsigner/src/main/java/org/apache/maven/shared/jarsigner/JarSignerCommandLineBuilder.java
@@ -211,6 +211,13 @@ public class JarSignerCommandLineBuilder
             cli.createArg().setValue( "-signedjar" );
             cli.createArg().setValue( signedjar.getAbsolutePath() );
         }
+        
+        final File certchain = request.getCertchain();
+        if ( certchain != null )
+        {
+            cli.createArg().setValue( "-certchain" );
+            cli.createArg().setValue( certchain.getAbsolutePath() );
+        }
     }
 
     protected void build( JarSignerVerifyRequest request, Commandline cli )

--- a/maven-jarsigner/src/main/java/org/apache/maven/shared/jarsigner/JarSignerSignRequest.java
+++ b/maven-jarsigner/src/main/java/org/apache/maven/shared/jarsigner/JarSignerSignRequest.java
@@ -57,6 +57,13 @@ public class JarSignerSignRequest
      */
     protected File signedjar;
 
+    /**
+     * Location of the extra certchain file to be used during signing.
+     * 
+     * See <a href="http://docs.oracle.com/javase/7/docs/technotes/tools/windows/jarsigner.html#Options">options</a>.
+     * @since TODO
+     */
+    protected File certchain;
 
     public String getKeypass()
     {
@@ -108,4 +115,23 @@ public class JarSignerSignRequest
         this.signedjar = signedjar;
     }
 
+    /**
+     * Sets certchain to be used.
+     * 
+     * @param certchain Cert Chain file path or {@code null} to remove the option
+     * @since TODO
+     */
+    public void setCertchain( File certchain )
+    {
+        this.certchain = certchain;
+    }
+
+    /**
+     * Get certificate chain.
+     * @return Path to the certificate chain file or {@code null} if undefined
+     */
+    public File getCertchain()
+    {
+        return certchain;
+    }
 }


### PR DESCRIPTION
This adds a new optional parameter for "certchain". If the maintainers are fine with the approach, I will add additional tests.

Downstream pull-request: https://github.com/apache/maven-plugins/pull/125

[MJARSIGNER-53](https://issues.apache.org/jira/browse/MJARSIGNER-53)
